### PR TITLE
Update deprecated binary log status query

### DIFF
--- a/tap_mysql/sync_strategies/binlog.py
+++ b/tap_mysql/sync_strategies/binlog.py
@@ -105,7 +105,12 @@ def verify_log_file_exists(mysql_conn, log_file, log_pos):
 def fetch_current_log_file_and_pos(mysql_conn):
     with connect_with_backoff(mysql_conn) as open_conn:
         with open_conn.cursor() as cur:
-            cur.execute("SHOW MASTER STATUS")
+            try:
+                cur.execute("SHOW BINARY LOG STATUS")
+                result = cur.fetchone()
+            except:
+                cur.execute("SHOW MASTER STATUS")
+                result = cur.fetchone()
 
             result = cur.fetchone()
 


### PR DESCRIPTION
> 15.7.7.24 SHOW MASTER STATUS Statement (no longer supported)
This statement is no longer supported, and has been replaced by [SHOW BINARY LOG STATUS](https://dev.mysql.com/doc/refman/8.4/en/show-binary-log-status.html).

Source: [MySQL 8.4 Reference Manual :: 15.7.7.24 SHOW MASTER STATUS Statement (no longer supported](https://dev.mysql.com/doc/refman/8.4/en/show-master-status.html)